### PR TITLE
Added where clause tests for Supplier and purchased products.

### DIFF
--- a/server/database/models/tests/purchasedProduct/where-clause.test.js
+++ b/server/database/models/tests/purchasedProduct/where-clause.test.js
@@ -1,0 +1,47 @@
+/* eslint-disable no-useless-escape */
+import { purchasedProductsTable } from 'server/utils/testUtils/mockData';
+import { testApp } from 'server/utils/testUtils/testApp';
+import { addWhereClause } from 'utils';
+
+var request = require('supertest');
+let spy;
+beforeEach(() => {
+  const mockDBClient = require('database');
+  const client = mockDBClient.client;
+  spy = jest.spyOn(client, 'query');
+  client.$queueQueryResult([{}, { rows: [{ ...purchasedProductsTable }] }]);
+  jest.doMock('database', () => ({ client, getClient: () => client }));
+});
+
+describe('PurchasedProduct Table where clause tests', () => {
+  const purchasedProductName = `
+  query {
+    purchasedProduct (id: 1) {
+      id
+      price
+    }
+  }
+    `;
+
+  let where = `TRUE`;
+  where = addWhereClause(where, `\"purchasedP\".id = 1`);
+  where = addWhereClause(where, `\"purchasedP\".deleted_at IS NULL `);
+
+  const sqlQuery = `SELECT
+  \"purchasedP\".\"id\" AS \"id\",
+  \"purchasedP\".\"price\" AS \"price\"
+FROM purchased_products \"purchasedP\"
+WHERE ${where}`;
+
+  it('should generate the correct sql query for purchasedProduct table', async done => {
+    await request(testApp)
+      .post('/graphql')
+      .type('form')
+      .send({ query: purchasedProductName })
+      .set('Accept', 'application/json')
+      .then(() => {
+        expect(spy).toHaveBeenCalledWith(sqlQuery);
+        done();
+      });
+  });
+});

--- a/server/database/models/tests/supplier/where-clause.test.js
+++ b/server/database/models/tests/supplier/where-clause.test.js
@@ -27,10 +27,10 @@ describe('Supplier Table where clause tests', () => {
   where = addWhereClause(where, `\"supplier\".deleted_at IS NULL `);
 
   const sqlQuery = `SELECT
-    \"supplier\".\"id\" AS \"id\",
-    \"supplier\".\"name\" AS \"name\"
-  FROM suppliers \"supplier\"
-  WHERE ${where}`;
+  \"supplier\".\"id\" AS \"id\",
+  \"supplier\".\"name\" AS \"name\"
+FROM suppliers \"supplier\"
+WHERE ${where}`;
 
   it('should generate the correct sql query for supplier table', async done => {
     await request(testApp)

--- a/server/database/models/tests/supplier/where-clause.test.js
+++ b/server/database/models/tests/supplier/where-clause.test.js
@@ -1,0 +1,55 @@
+/* eslint-disable no-useless-escape */
+import { suppliersTable } from 'server/utils/testUtils/mockData';
+import { testApp } from 'server/utils/testUtils/testApp';
+import { addWhereClause } from 'utils';
+var request = require('supertest');
+let spy;
+beforeEach(() => {
+  const mockDBClient = require('database');
+  const client = mockDBClient.client;
+  spy = jest.spyOn(client, 'query');
+  client.$queueQueryResult([{}, { rows: [{ ...suppliersTable }] }]);
+  jest.doMock('database', () => ({ client, getClient: () => client }));
+});
+
+describe('Supplier Table where clause tests', () => {
+  const supplierName = `
+    query {
+      supplier (id: 1) {
+        id
+        name
+      }
+    }
+    `;
+  let where = ``;
+  where = escape(`"supplier".id=1 `);
+  where = addWhereClause(where, `\"supplier\".id = 1`);
+  where = addWhereClause(where, `\"supplier\".deleted_at IS NULL `);
+
+  const sqlQuery = `SELECT
+    \"supplier\".\"id\" AS \"id\",
+    \"supplier\".\"name\" AS \"name\"
+  FROM suppliers \"supplier\"
+  WHERE ${where}`;
+
+  it('should generate the correct sql query for supplier table', async done => {
+    await request(testApp)
+      .post('/graphql')
+      .type('form')
+      .send({ query: supplierName })
+      .set('Accept', 'application/json')
+      .then(() => {
+        expect(spy).toHaveBeenCalledWith(sqlQuery);
+        done();
+      });
+  });
+  it('should produce the correct where clause for supplier table', async done => {
+    where = escape(`supplier.id=1 `);
+    where = addWhereClause(where, `supplier.id = 1`);
+    where = addWhereClause(where, `supplier.deleted_at IS NULL `);
+    const { addQueries } = require('gql/queries');
+    const result = addQueries().supplier.where('supplier', { id: 1 });
+    expect(result).toBe(where);
+    done();
+  });
+});


### PR DESCRIPTION
### Description

Added tests to check the where clause for `Supplier` table. The sql query passed on to `client.query()` was matched to an expected value with the where clause. The alias where field was also tested by passing args and spying the `addQueries` object.

**Note**
Instead the where clauses for all the `aliasTables` connected to purchased products are created by join monster. The where field in purchasedProducts in CONNECTIONS  doesn't return a where value.