### PR TITLE
Added tests for migration utils

### DIFF
--- a/server/utils/tests/migrationUtils.test.js
+++ b/server/utils/tests/migrationUtils.test.js
@@ -1,0 +1,56 @@
+describe('migrationUtils tests', () => {
+  jest.mock('shelljs', () => ({
+    ls: () => ['test_file_name_1', 'test_file_name_2']
+  }));
+  jest.mock('fs', () => ({
+    readFileSync: () => {}
+  }));
+  it('should export a getVersion function that returns the version of the current migration', () => {
+    const { getVersion } = require('./../migrateUtils');
+    const version = getVersion('test_file_name_2');
+    expect(version).toBe(2);
+  });
+  it('should extract the version from the currentFile and pass the resources to query', () => {
+    const fs = require('fs');
+    const fsSpy = jest.spyOn(fs, 'readFileSync');
+    const { migrate } = require('./../migrateUtils');
+    const query = jest.fn(async () => {});
+    const queryInterface = {
+      sequelize: {
+        query
+      }
+    };
+    migrate('test_file_name_2', queryInterface);
+    const filesInResourcesVersion = ['test_file_name_1', 'test_file_name_2'];
+    expect(fsSpy).toHaveBeenCalledWith(`./resources/v${2}/${filesInResourcesVersion[0]}`, 'utf-8');
+  });
+  it('should have a migrate function that calls query for all migrations', () => {
+    const { migrate } = require('./../migrateUtils');
+    const query = jest.fn(async () => {});
+    const queryInterface = {
+      sequelize: {
+        query
+      }
+    };
+    const result = migrate('test_file_name_2', queryInterface);
+    expect(result);
+    expect(query).toHaveBeenCalled();
+  });
+  it('should have a migrate function that catches a sql error if the migration fails', async () => {
+    const sqlError = new Error();
+    sqlError.original = {
+      sqlMessage: {
+        startsWith: () => true,
+        endsWith: () => true
+      }
+    };
+    const query = jest.fn(() => new Promise((resolve, reject) => reject(sqlError)));
+    const { migrate } = require('./../migrateUtils');
+    const queryInterface = {
+      sequelize: {
+        query
+      }
+    };
+    expect(await migrate('test_file_name_2', queryInterface)).toBeFalsy();
+  });
+});


### PR DESCRIPTION
### Description

Added tests for migration utils. Mocked packages and arguments to properly test the methods in migration utils.

**Note**
Line 27 was not tested because the first class argument function which is mocked throws instead of the function that  is being tested. Since we cannot expect if the mocked function throw an error, this case was omitted.