### PR TITLE
feat: Peek module definitions for webpack alias

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@server/*": ["server/*"],
+      "@root/*": ["*"],
+      "@utils/*": ["server/utils/*"],
+      "@middleware/*": ["server/middleware/*"],
+      "@services/*": ["server/services/*"],
+      "@daos/*": ["server/daos/*"],
+      "@database/*": ["server/database/*"],
+      "@gql/*": ["server/gql/*"],
+      "@config/*": ["config/*"]
+    },
+    "moduleResolution": "Node"
+  },
+  "exclude": ["./node_modules", "dist"]
+}


### PR DESCRIPTION
### Ticket Link

---

### Related Links

---

### Description

- Added jsconfig to support "Go to Definition" for  webpack module aliases

### Steps to Reproduce / Test

---

---

### Checklist

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)

### GIF's

![2022-03-03 11 12 35](https://user-images.githubusercontent.com/98734275/156503903-439031dc-5cc4-4d41-ba28-1a7c8285ad99.gif)

